### PR TITLE
WIP: client: Initial PacketConn refactoring.

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,7 +3,6 @@ package stun
 import (
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"runtime"
@@ -11,55 +10,163 @@ import (
 	"time"
 )
 
-// Dial connects to the address on the named network and then
-// initializes Client on that connection, returning error if any.
-func Dial(network, address string) (*Client, error) {
-	conn, err := net.Dial(network, address)
-	if err != nil {
-		return nil, err
+const (
+	defaultTimeoutRate = time.Millisecond * 100
+	netUDP             = "udp"
+	netUDP4            = "udp4"
+	netUDP6            = "udp6"
+	DefaultNet         = "udp"
+	DefaultSTUNServer  = "gortc.io:3478"
+)
+
+var (
+	// ErrNoConnection means that ClientOptions.Connection is nil.
+	ErrNoConnection = errors.New("no connection provided")
+	// ErrConnection means that the client already has a connection set
+	ErrConnection = errors.New("connection already provided")
+	// ErrNet means the network type is not supported
+	ErrNet = errors.New("network type not supported")
+	// ErrClientClosed indicates that client is closed.
+	ErrClientClosed = errors.New("client is closed")
+)
+
+// Dial creates a stun connection to a STUN server
+// using the supplied options.
+func Dial(network, localaddress, stunserveraddress string, options ...func(*Client) error) (*Client, error) {
+	if stunserveraddress == "" {
+		stunserveraddress = DefaultSTUNServer
 	}
-	return NewClient(ClientOptions{
-		Connection: conn,
-	})
+	var laddr net.Addr
+	var err error
+	if localaddress != "" {
+		laddr, err = ResolveAddr(network, localaddress)
+		if err != nil {
+			return nil, fmt.Errorf("localaddr: %v", err)
+		}
+	}
+	raddr, err := ResolveAddr(network, stunserveraddress)
+	if err != nil {
+		return nil, fmt.Errorf("stunserveraddress: %v", err)
+	}
+	conn, err := listen(network, laddr)
+	if err != nil {
+		return nil, fmt.Errorf("listen: %v", err)
+	}
+
+	options = append(options, WithPacketConn(conn))
+	options = append(options, WithSTUNServer(raddr))
+
+	return NewClient(options...)
 }
 
-// ClientOptions are used to initialize Client.
-type ClientOptions struct {
-	Agent       ClientAgent
-	Connection  Connection
-	TimeoutRate time.Duration // defaults to 100 ms
+// ResolveAddr returns an address.
+func ResolveAddr(network, address string) (net.Addr, error) {
+	if network == "" {
+		network = DefaultNet
+	}
+
+	switch network {
+	case netUDP, netUDP4, netUDP6:
+		return net.ResolveUDPAddr(network, address)
+	default:
+		return nil, ErrNet
+	}
 }
 
-const defaultTimeoutRate = time.Millisecond * 100
+func listen(network string, laddr net.Addr) (PacketConn, error) {
+	switch network {
+	case netUDP, netUDP4, netUDP6:
+		var addr *net.UDPAddr
+		if laddr != nil {
+			addr = laddr.(*net.UDPAddr)
+		}
+		return net.ListenUDP(network, addr)
+	default:
+		return nil, ErrNet
+	}
+}
 
-// ErrNoConnection means that ClientOptions.Connection is nil.
-var ErrNoConnection = errors.New("no connection provided")
+// PacketConn represents a subset of net.PacketConn.
+type PacketConn interface {
+	ReadFrom(b []byte) (n int, addr net.Addr, err error)
+	WriteTo(b []byte, addr net.Addr) (n int, err error)
+	Close() error
+	LocalAddr() net.Addr
+}
 
-// NewClient initializes new Client from provided options,
-// starting internal goroutines and using default options fields
-// if necessary. Call Close method after using Client to release
-// resources.
-func NewClient(options ClientOptions) (*Client, error) {
+// Client simulates "connection" to STUN server.
+// The caller should either continuously call ReadFrom or
+// use ReadUntilClosed to keep transaction processing active.
+type Client struct {
+	a          ClientAgent
+	c          PacketConn
+	serveraddr net.Addr
+	close      chan struct{}
+	gcRate     time.Duration
+	closed     bool
+	closedMux  sync.RWMutex
+	wg         sync.WaitGroup
+}
+
+// Client itself implements the PacketConn interface
+var _ PacketConn = (*Client)(nil)
+
+// NewClient initializes new Client manually from provided options.
+// Usage of Dial is preffered for most applications.
+func NewClient(options ...func(*Client) error) (*Client, error) {
 	c := &Client{
 		close:  make(chan struct{}),
-		c:      options.Connection,
-		a:      options.Agent,
-		gcRate: options.TimeoutRate,
+		gcRate: defaultTimeoutRate,
 	}
+
+	for _, option := range options {
+		option(c)
+	}
+
 	if c.c == nil {
 		return nil, ErrNoConnection
 	}
 	if c.a == nil {
 		c.a = NewAgent(AgentOptions{})
 	}
-	if c.gcRate == 0 {
-		c.gcRate = defaultTimeoutRate
-	}
-	c.wg.Add(2)
-	go c.readUntilClosed()
-	go c.collectUntilClosed()
+
 	runtime.SetFinalizer(c, clientFinalizer)
 	return c, nil
+}
+
+// WithTimeoutRate allows the default timeout rate of 100ms to be overwritten.
+func WithTimeoutRate(d time.Duration) func(*Client) error {
+	return func(c *Client) error {
+		c.gcRate = d
+		return nil
+	}
+}
+
+// WithAgent allows overwriting the default stun.ClientAgent.
+func WithAgent(a ClientAgent) func(*Client) error {
+	return func(c *Client) error {
+		c.a = a
+		return nil
+	}
+}
+
+// WithPacketConn
+func WithPacketConn(conn PacketConn) func(*Client) error {
+	return func(c *Client) error {
+		if c.c != nil {
+			return ErrConnection
+		}
+		c.c = conn
+		return nil
+	}
+}
+
+// WithSTUNServer
+func WithSTUNServer(addr net.Addr) func(*Client) error {
+	return func(c *Client) error {
+		c.serveraddr = addr
+		return nil
+	}
 }
 
 func clientFinalizer(c *Client) {
@@ -77,13 +184,6 @@ func clientFinalizer(c *Client) {
 	log.Println("client: called finalizer on non-closed client:", err)
 }
 
-// Connection wraps Reader, Writer and Closer interfaces.
-type Connection interface {
-	io.Reader
-	io.Writer
-	io.Closer
-}
-
 // ClientAgent is Agent implementation that is used by Client to
 // process transactions.
 type ClientAgent interface {
@@ -92,17 +192,6 @@ type ClientAgent interface {
 	Start(id [TransactionIDSize]byte, deadline time.Time, f Handler) error
 	Stop(id [TransactionIDSize]byte) error
 	Collect(time.Time) error
-}
-
-// Client simulates "connection" to STUN server.
-type Client struct {
-	a         ClientAgent
-	c         Connection
-	close     chan struct{}
-	gcRate    time.Duration
-	closed    bool
-	closedMux sync.RWMutex
-	wg        sync.WaitGroup
 }
 
 // StopErr occurs when Client fails to stop transaction while
@@ -137,21 +226,36 @@ func (c CloseErr) Error() string {
 	)
 }
 
+// HandleTransactions is a convenience method which
+// starts ReadUntilClosed and CollectUntilClosed
+// and is used to automatically process and garbage collect transactions.
+// Non-stun messages are dropped. Alternatively, use ReadFrom to
+// manually process transactions and handle non-stun messages.
+func (c *Client) HandleTransactions() {
+	c.ReadUntilClosed()
+	c.CollectUntilClosed()
+}
+
+// ReadUntilClosed is used to automatically process transactions.
+// Non-stun messages are dropped. Alternatively, use ReadFrom to
+// manually process transactions and handle non-stun messages.
+func (c *Client) ReadUntilClosed() {
+	c.wg.Add(1)
+	go c.readUntilClosed()
+}
+
 func (c *Client) readUntilClosed() {
 	defer c.wg.Done()
-	m := new(Message)
-	m.Raw = make([]byte, 1024)
+	buf := make([]byte, 1024)
 	for {
 		select {
 		case <-c.close:
 			return
 		default:
 		}
-		_, err := m.ReadFrom(c.c)
-		if err == nil {
-			if pErr := c.a.Process(m); pErr == ErrAgentClosed {
-				return
-			}
+		_, _, err := c.ReadFrom(buf)
+		if err == ErrAgentClosed {
+			return
 		}
 	}
 }
@@ -163,22 +267,32 @@ func closedOrPanic(err error) {
 	panic(err)
 }
 
+// CollectUntilClosed is used to atimatically trigger transaction garbage collection.
+// Alternatively, use Collect for manual collection.
+func (c *Client) CollectUntilClosed() {
+	c.wg.Add(1)
+	go c.collectUntilClosed()
+}
+
 func (c *Client) collectUntilClosed() {
-	t := time.NewTicker(c.gcRate)
 	defer c.wg.Done()
+	t := time.NewTicker(c.gcRate)
 	for {
 		select {
 		case <-c.close:
 			t.Stop()
 			return
 		case gcTime := <-t.C:
-			closedOrPanic(c.a.Collect(gcTime))
+			closedOrPanic(c.Collect(gcTime))
 		}
 	}
 }
 
-// ErrClientClosed indicates that client is closed.
-var ErrClientClosed = errors.New("client is closed")
+// Collect is used to manually trigger transaction collection.
+// Alternatively, use CollectUntilClosed for automated collection.
+func (c *Client) Collect(gcTime time.Time) error {
+	return c.a.Collect(gcTime)
+}
 
 // Close stops internal connection and agent, returning CloseErr on error.
 func (c *Client) Close() error {
@@ -266,34 +380,15 @@ func (c *Client) checkInit() error {
 	return nil
 }
 
-// Do is Start wrapper that waits until callback is called. If no callback
-// provided, Indicate is called instead.
-//
-// Do has cpu overhead due to blocking, see BenchmarkClient_Do.
-// Use Start method for less overhead.
-func (c *Client) Do(m *Message, d time.Time, f func(Event)) error {
-	if err := c.checkInit(); err != nil {
-		return err
-	}
-	if f == nil {
-		return c.Indicate(m)
-	}
-	h := callbackWaitHandlerPool.Get().(*callbackWaitHandler)
-	h.setCallback(f)
-	defer func() {
-		h.reset()
-		callbackWaitHandlerPool.Put(h)
-	}()
-	if err := c.Start(m, d, h); err != nil {
-		return err
-	}
-	h.wait()
-	return nil
-}
-
-// Start starts transaction (if f set) and writes message to server, handler
+// Start starts transaction (if h set) and writes message to server, handler
 // is called asynchronously.
 func (c *Client) Start(m *Message, d time.Time, h Handler) error {
+	return c.StartTo(m, c.serveraddr, d, h)
+}
+
+// StartTo starts transaction (if h set) and writes message to a specific peer, handler
+// is called asynchronously.
+func (c *Client) StartTo(m *Message, raddr net.Addr, d time.Time, h Handler) error {
 	if err := c.checkInit(); err != nil {
 		return err
 	}
@@ -309,7 +404,7 @@ func (c *Client) Start(m *Message, d time.Time, h Handler) error {
 			return err
 		}
 	}
-	_, err := m.WriteTo(c.c)
+	_, err := c.c.WriteTo(m.Raw, raddr)
 	if err != nil && h != nil {
 		// Stopping transaction instead of waiting until deadline.
 		if stopErr := c.a.Stop(m.TransactionID); stopErr != nil {
@@ -320,4 +415,74 @@ func (c *Client) Start(m *Message, d time.Time, h Handler) error {
 		}
 	}
 	return err
+}
+
+// Do is Start wrapper that waits until callback is called. If no callback
+// provided, Indicate is called instead.
+//
+// Do has cpu overhead due to blocking, see BenchmarkClient_Do.
+// Use Start method for less overhead.
+func (c *Client) Do(m *Message, d time.Time) (*Message, error) {
+	return c.DoTo(m, c.serveraddr, d)
+}
+
+// DoTo is StartTo wrapper that waits until callback is called. If no callback
+// provided, Indicate is called instead.
+//
+// Do has cpu overhead due to blocking, see BenchmarkClient_Do.
+// Use Start method for less overhead.
+func (c *Client) DoTo(m *Message, raddr net.Addr, d time.Time) (*Message, error) {
+	if err := c.checkInit(); err != nil {
+		return nil, err
+	}
+	h := callbackWaitHandlerPool.Get().(*callbackWaitHandler)
+	var eventErr error
+	var message *Message
+	h.setCallback(func(event Event) {
+		eventErr = event.Error
+		message = event.Message
+	})
+	defer func() {
+		h.reset()
+		callbackWaitHandlerPool.Put(h)
+	}()
+	if err := c.StartTo(m, raddr, d, h); err != nil {
+		return nil, err
+	}
+	h.wait()
+	return message, eventErr
+}
+
+// ReadFrom is used to keep transaction processing aliv and
+// receive non-stun messages over the connection. Alternatively,
+// See ReadUntilClosed for automated transaction processing.
+func (c *Client) ReadFrom(b []byte) (n int, addr net.Addr, err error) {
+	for {
+		n, addr, err = c.c.ReadFrom(b)
+		if err != nil {
+			return
+		}
+		if !IsMessage(b[:n]) {
+			return
+		}
+		m := new(Message)
+		m.Raw = b[:n]
+		if m.Decode() != nil {
+			return // The caller may be able to handle the packet
+		}
+		err = c.a.Process(m)
+		if err != nil {
+			return
+		}
+	}
+}
+
+// WriteTo is used to write a message over the connection to the remote peer
+func (c *Client) WriteTo(b []byte, addr net.Addr) (int, error) {
+	return c.c.WriteTo(b, addr)
+}
+
+// LocalAddr returns the local network address.
+func (c *Client) LocalAddr() net.Addr {
+	return c.c.LocalAddr()
 }

--- a/client.go
+++ b/client.go
@@ -33,6 +33,9 @@ var (
 // Dial creates a stun connection to a STUN server
 // using the supplied options.
 func Dial(network, localaddress, stunserveraddress string, options ...func(*Client) error) (*Client, error) {
+	if network == "" {
+		network = DefaultNet
+	}
 	if stunserveraddress == "" {
 		stunserveraddress = DefaultSTUNServer
 	}

--- a/client.go
+++ b/client.go
@@ -314,10 +314,16 @@ func (c *Client) Close() error {
 	}
 }
 
-// Indicate sends indication m to server. Shorthand to Start call
+// Indicate sends indication m the stun server. Shorthand to Start call
 // with zero deadline and callback.
 func (c *Client) Indicate(m *Message) error {
 	return c.Start(m, time.Time{}, nil)
+}
+
+// IndicateTo sends indication m to a peer. Shorthand to StartTo call
+// with zero deadline and callback.
+func (c *Client) IndicateTo(m *Message, raddr net.Addr) error {
+	return c.StartTo(m, raddr, time.Time{}, nil)
 }
 
 // callbackWaitHandler blocks on wait() call until callback is called.

--- a/cmd/stun-traversal/Readme.md
+++ b/cmd/stun-traversal/Readme.md
@@ -1,1 +1,2 @@
 stun-traversal is a small NAT traversal proof of concept using package gortc/stun. Peer exchange is done manually using stdin.
+Note: The demo may fail due to packetloss until #39 is fixed.

--- a/cmd/stun-traversal/main.go
+++ b/cmd/stun-traversal/main.go
@@ -39,7 +39,6 @@ func main() {
 
 	// Start listening to start transaction handling
 	messageChan := readUntilClosed(c)
-	c.CollectUntilClosed()
 
 	err = getPubAddr(c)
 	if err != nil {

--- a/cmd/stun-traversal/main.go
+++ b/cmd/stun-traversal/main.go
@@ -14,40 +14,42 @@ import (
 )
 
 var (
-	server = flag.String("server", fmt.Sprintf("gortc.io:3478"), "Stun server address")
+	network = flag.String("network", stun.DefaultNet, "Stun network type")
+	server  = flag.String("server", stun.DefaultSTUNServer, "Stun server address")
+	local   = flag.String("local", "", "Local network address")
 )
 
 const (
-	udp           = "udp4"
-	pingMsg       = "ping"
-	pongMsg       = "pong"
-	timeoutMillis = 500
+	pingMsg         = "ping"
+	pongMsg         = "pong"
+	keepaliveMillis = 500
 )
 
 func main() {
 	flag.Parse()
 
-	srvAddr, err := net.ResolveUDPAddr(udp, *server)
-	if err != nil {
-		log.Fatalln("resolve serveraddr:", err)
-	}
-
-	conn, err := net.ListenUDP(udp, nil)
+	c, err := stun.Dial(*network, *local, *server)
 	if err != nil {
 		log.Fatalln("dial:", err)
 	}
 
-	defer conn.Close()
+	defer c.Close()
 
-	log.Printf("Listening on %s\n", conn.LocalAddr())
+	log.Printf("Listening on %s\n", c.LocalAddr())
 
-	var publicAddr stun.XORMappedAddress
-	var peerAddr *net.UDPAddr
+	// Start listening to start transaction handling
+	messageChan := readUntilClosed(c)
+	c.CollectUntilClosed()
 
-	messageChan := listen(conn)
-	var peerAddrChan <-chan string
+	err = getPubAddr(c)
+	if err != nil {
+		log.Fatalln("get pub addr:", err)
+	}
 
-	keepalive := time.Tick(timeoutMillis * time.Millisecond)
+	var peerAddr net.Addr
+	peerAddrChan := getPeerAddr()
+
+	keepalive := time.Tick(keepaliveMillis * time.Millisecond)
 	keepaliveMsg := pingMsg
 
 	var quit <-chan time.Time
@@ -77,43 +79,19 @@ func main() {
 
 				gotPong = true
 
-			case stun.IsMessage(message):
-				m := new(stun.Message)
-				m.Raw = message
-				err := m.Decode()
-				if err != nil {
-					log.Println("decode:", err)
-					break
-				}
-				var xorAddr stun.XORMappedAddress
-				if err := xorAddr.GetFrom(m); err != nil {
-					log.Println("getFrom:", err)
-					break
-				}
-
-				if publicAddr.String() != xorAddr.String() {
-					log.Printf("My public address: %s\n", xorAddr)
-					publicAddr = xorAddr
-
-					peerAddrChan = getPeerAddr()
-				}
-
 			default:
 				log.Fatalln("unknown message", message)
 			}
 
-		case peerStr := <-peerAddrChan:
-			peerAddr, err = net.ResolveUDPAddr(udp, peerStr)
-			if err != nil {
-				log.Fatalln("resolve peeraddr:", err)
-			}
+		case addr := <-peerAddrChan:
+			peerAddr = addr
 
 		case <-keepalive:
 			// Keep NAT binding alive using STUN server or the peer once it's known
 			if peerAddr == nil {
-				err = sendBindingRequest(conn, srvAddr)
+				err = c.Indicate(stun.MustBuild(stun.TransactionID, stun.BindingRequest))
 			} else {
-				err = sendStr(keepaliveMsg, conn, peerAddr)
+				_, err = c.WriteTo([]byte(keepaliveMsg), peerAddr)
 				if keepaliveMsg == pongMsg {
 					sentPong = true
 				}
@@ -124,7 +102,7 @@ func main() {
 			}
 
 		case <-quit:
-			conn.Close()
+			c.Close()
 		}
 
 		if quit == nil && gotPong && sentPong {
@@ -134,58 +112,57 @@ func main() {
 	}
 }
 
-func getPeerAddr() <-chan string {
-	result := make(chan string)
+func getPubAddr(c *stun.Client) error {
+	deadline := time.Now().Add(time.Second * 5)
+	message, err := c.Do(stun.MustBuild(stun.TransactionID, stun.BindingRequest), deadline)
+	if err != nil {
+		return fmt.Errorf("do: %v", err)
+	}
+	var publicAddr stun.XORMappedAddress
+	if err := publicAddr.GetFrom(message); err != nil {
+		return fmt.Errorf("get from: %v", err)
+	}
+
+	log.Printf("My public address: %s\n", publicAddr)
+
+	return nil
+}
+
+func getPeerAddr() <-chan net.Addr {
+	result := make(chan net.Addr)
 
 	go func() {
 		reader := bufio.NewReader(os.Stdin)
 		log.Println("Enter remote peer address:")
-		peer, _ := reader.ReadString('\n')
-		result <- strings.Trim(peer, " \r\n")
+		for {
+			peer, _ := reader.ReadString('\n')
+			addr, err := stun.ResolveAddr(*network, strings.Trim(peer, " \r\n"))
+			if err != nil {
+				log.Println("Invalid address:", err)
+				continue
+			}
+			result <- addr
+			return
+		}
 	}()
 
 	return result
 }
 
-func listen(conn *net.UDPConn) <-chan []byte {
+func readUntilClosed(conn stun.PacketConn) <-chan []byte {
 	messages := make(chan []byte)
 	go func() {
 		for {
 			buf := make([]byte, 1024)
 
-			n, _, err := conn.ReadFromUDP(buf)
+			n, _, err := conn.ReadFrom(buf)
 			if err != nil {
 				close(messages)
 				return
 			}
-			buf = buf[:n]
 
-			messages <- buf
+			messages <- buf[:n]
 		}
 	}()
 	return messages
-}
-
-func sendBindingRequest(conn *net.UDPConn, addr *net.UDPAddr) error {
-	m := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
-
-	err := send(m.Raw, conn, addr)
-	if err != nil {
-		return fmt.Errorf("binding: %v", err)
-	}
-
-	return nil
-}
-
-func send(msg []byte, conn *net.UDPConn, addr *net.UDPAddr) error {
-	_, err := conn.WriteToUDP(msg, addr)
-	if err != nil {
-		return fmt.Errorf("send: %v", err)
-	}
-
-	return nil
-}
-
-func sendStr(msg string, conn *net.UDPConn, addr *net.UDPAddr) error {
-	return send([]byte(msg), conn, addr)
 }

--- a/integration-test/main.go
+++ b/integration-test/main.go
@@ -57,12 +57,28 @@ func main() {
 	if err = response.Parse(&xorMapped); err != nil {
 		log.Fatalln("failed to parse xor mapped address:", err)
 	}
-	if laddr.String() != xorMapped.String() {
+	lport, err := getPort(laddr)
+	if err != nil {
+		log.Fatalln("get port:", laddr)
+	}
+	if lport != xorMapped.Port {
 		log.Fatalln(laddr, "!=", xorMapped)
 	}
 	fmt.Println("OK", response, "GOT", xorMapped)
 
 	if err := client.Close(); err != nil {
 		log.Fatalln("failed to close client:", err)
+	}
+}
+
+// Get the port of a net.Addr
+func getPort(addr net.Addr) (int, error) {
+	switch a := addr.(type) {
+	case *net.UDPAddr:
+		return a.Port, nil
+	case *net.TCPAddr:
+		return a.Port, nil
+	default:
+		return -1, stun.ErrNet
 	}
 }

--- a/integration-test/main.go
+++ b/integration-test/main.go
@@ -33,6 +33,9 @@ func main() {
 	if err != nil {
 		log.Fatalln("failed to dial:", err)
 	}
+
+	client.HandleTransactions()
+
 	laddr := client.LocalAddr()
 	fmt.Println("LISTEN ON", laddr)
 


### PR DESCRIPTION
This WIP PR addresses #41. I created it already to get some early feedback. Still TODO:
- [x] Test integration-test
- [ ] Incorporate feedback.
- [ ] Fix test coverage.
- [ ] Update documentation.


High-level overview of changes:
- Refactored the networking of stun.Client around a subset of net.PacketConn.
- stun.Client also implements the PacketConn interface itself to allow layering of the client, E.g.: by turn.Client.
- Made ReadUntilClosed optional. The caller can instead opt to call Client.ReadFrom continuously. This seems like a simple way to enable both multiplexing and handling non-stun messages on the same connection.
- Removed the callback option from Client.Do to create a more natural blocking API.
- Initial scaffolding for supporting multiple transports.
- Added StartTo, IndicateTo and DoTo to allow sending stun transaction to a peer instead of the stun server.
- Refactored the clients under cmd and integration-test. Most clients, especially cmd/stun-traversal, are significantly more straightforward now.
- Tested the clients under cmd.

I'm not entirely happy with having to call HandleTransactions after starting the client in simple use-cases. I'm not sure if there is an obvious way to solve this. In addition, there is an unlikely 'deadlock' scenario in stun-traversal if a non-stun message is received before the response to the binding request. This shows that, while convenient, the blocking API does have some caveats.
Lastly, I haven't put much thought into it but this implementation of stun.Client may be usable as a server as well.