### PR TITLE
Unlambda test functions

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1275,9 +1275,7 @@ func TestClientRTOAgentErr(t *testing.T) {
 	connL, connR := net.Pipe()
 	defer connL.Close()
 	collector := new(manualCollector)
-	clock := callbackClock(func() time.Time {
-		return time.Now()
-	})
+	clock := callbackClock(time.Now)
 	agent := &manualAgent{}
 	attempt := 0
 	gotReads := make(chan struct{})
@@ -1341,9 +1339,7 @@ func TestClient_HandleProcessError(t *testing.T) {
 	connL, connR := net.Pipe()
 	defer connL.Close()
 	collector := new(manualCollector)
-	clock := callbackClock(func() time.Time {
-		return time.Now()
-	})
+	clock := callbackClock(time.Now)
 	agent := &manualAgent{}
 	gotWrites := make(chan struct{})
 	processCalled := make(chan struct{}, 1)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -192,9 +192,7 @@ func TestMessage_ForEach(t *testing.T) {
 			m = newMessage()
 			var realm Realm
 			testutil.ShouldNotAllocate(t, func() {
-				if err := m.ForEach(AttrRealm, func(m *Message) error {
-					return realm.GetFrom(m)
-				}); err != nil {
+				if err := m.ForEach(AttrRealm, realm.GetFrom); err != nil {
 					t.Fatal(err)
 				}
 			})


### PR DESCRIPTION
No need to wrap these functions, they already have a matching signature.